### PR TITLE
fix: add data path customization

### DIFF
--- a/configs/letsencrypt/init-letsencrypt.sh
+++ b/configs/letsencrypt/init-letsencrypt.sh
@@ -14,12 +14,15 @@ Options:
     --email=                An email address to receive renewal notifications.
 
     --staging               Use in testing environments to avoid rate limits.
+
+    --data_path=             Customize where to save the certificate files
 "
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
   --help) echo "$usage" ; exit 0 ;;
   --email) email="$2" ; shift ;;
+  --data_path) data_path="$2" ; shift ;;
   --staging) staging=1 ;;
   --) shift ; break ;;
   *) echo "Unknown parameter passed: $1" >&2 ; exit 1 ;;
@@ -39,10 +42,8 @@ if ! [ -x "$(command -v docker-compose)" ]; then
 fi
 
 if [ -d "$data_path" ]; then
-  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
-  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
-    exit
-  fi
+  echo "Existing data found for $domains at $data_path."
+  exit 0
 fi
 
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
@@ -90,7 +91,7 @@ case "$email" in
 esac
 
 # Enable staging mode if needed
-if [ $staging != "0" ]; then staging_arg="--staging"; fi
+if [ $staging != "0" ]; then staging_arg="--staging"; else staging_arg=""; fi
 
 docker-compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \

--- a/configs/letsencrypt/init-letsencrypt.sh
+++ b/configs/letsencrypt/init-letsencrypt.sh
@@ -100,8 +100,9 @@ docker-compose run --rm --entrypoint "\
     $domain_args \
     --rsa-key-size $rsa_key_size \
     --agree-tos \
+    --non-interactive \
     --force-renewal" certbot
 echo
 
 echo "### Reloading nginx ..."
-docker-compose exec gateway nginx -s reload
+docker-compose exec -T gateway nginx -s reload

--- a/templates/aws/eb/Preview/.ebextensions/ssl.config.dist
+++ b/templates/aws/eb/Preview/.ebextensions/ssl.config.dist
@@ -4,4 +4,4 @@ commands:
 
 container_commands:
     01_create_ssl_certificate:
-        command: "sh init-letsencrypt.sh && rm init-letsencrypt.sh"
+        command: "sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com && rm init-letsencrypt.sh"

--- a/templates/aws/eb/Single/.ebextensions/ssl.config.dist
+++ b/templates/aws/eb/Single/.ebextensions/ssl.config.dist
@@ -4,4 +4,4 @@ commands:
 
 container_commands:
     01_create_ssl_certificate:
-        command: "sh init-letsencrypt.sh --email user@company.com -- example.com www.example.com && rm init-letsencrypt.sh"
+        command: "sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com && rm init-letsencrypt.sh"

--- a/templates/aws/eb/Single/README.md
+++ b/templates/aws/eb/Single/README.md
@@ -131,7 +131,7 @@ DOMAIN_NAME: example.com
 ```
 * Inside `.ebextensions/ssl.config` update the domain names and email address:
 ```shell
-sh init-letsencrypt.sh --email user@company.com -- example.com www.example.com
+sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com
 ```
 * Redeploy the application
 ```shell

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux -o pipefail
+set -eu -o pipefail
 
 version="0.0.1"
 

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu -o pipefail
+set -eux -o pipefail
 
 version="0.0.1"
 


### PR DESCRIPTION
* `docker-compose exec -T ` to allow use without a tty
* `--non-interactive` to remove certbot warning: `Skipped user interaction because Certbot doesn't appear to be running in a terminal. You should probably include --non-interactive or --force-interactive on the command line.`
* `--data_path` option to override default path