### PR TITLE
Fix ssl interferance lifecycle

### DIFF
--- a/configs/letsencrypt/init-letsencrypt.sh
+++ b/configs/letsencrypt/init-letsencrypt.sh
@@ -41,8 +41,8 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-if [ -d "$data_path/live/$domains" ]; then
-  echo "Certificate already exists at $data_path/live/$domains."
+if [ -d "$data_path/conf/live/$domains" ]; then
+  echo "Certificate already exists at $data_path/conf/live/$domains."
   exit 0
 fi
 

--- a/configs/letsencrypt/init-letsencrypt.sh
+++ b/configs/letsencrypt/init-letsencrypt.sh
@@ -41,8 +41,8 @@ if ! [ -x "$(command -v docker-compose)" ]; then
   exit 1
 fi
 
-if [ -d "$data_path" ]; then
-  echo "Existing data found for $domains at $data_path."
+if [ -d "$data_path/live/$domains" ]; then
+  echo "Certificate already exists at $data_path/live/$domains."
   exit 0
 fi
 

--- a/templates/aws/eb/Preview/.ebextensions/ssl.config.dist
+++ b/templates/aws/eb/Preview/.ebextensions/ssl.config.dist
@@ -1,7 +1,3 @@
 commands:
   01_create_ssl:
     command: "mkdir -p /supportpal/ssl"
-
-container_commands:
-    01_create_ssl_certificate:
-        command: "sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com && rm init-letsencrypt.sh"

--- a/templates/aws/eb/Preview/.platform/hooks/postdeploy/01_setup_ssl.sh.dist
+++ b/templates/aws/eb/Preview/.platform/hooks/postdeploy/01_setup_ssl.sh.dist
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sh /var/app/current/init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com

--- a/templates/aws/eb/Single/.ebextensions/ssl.config.dist
+++ b/templates/aws/eb/Single/.ebextensions/ssl.config.dist
@@ -1,7 +1,3 @@
 commands:
   01_create_ssl:
     command: "mkdir -p /supportpal/ssl"
-
-container_commands:
-    01_create_ssl_certificate:
-        command: "sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com && rm init-letsencrypt.sh"

--- a/templates/aws/eb/Single/.ebignore
+++ b/templates/aws/eb/Single/.ebignore
@@ -1,2 +1,3 @@
 /.ebextensions/*.dist
+/.platform/hooks/postdeploy/*.dist
 /*.dist

--- a/templates/aws/eb/Single/.gitignore
+++ b/templates/aws/eb/Single/.gitignore
@@ -1,4 +1,5 @@
 #config files
+/.platform/hooks/postdeploy/*.sh
 /gateway/
 /docker-compose.yml
 /docker-compose.override.yml

--- a/templates/aws/eb/Single/.platform/hooks/postdeploy/01_setup_ssl.sh.dist
+++ b/templates/aws/eb/Single/.platform/hooks/postdeploy/01_setup_ssl.sh.dist
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sh /var/app/current/init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com

--- a/templates/aws/eb/Single/README.md
+++ b/templates/aws/eb/Single/README.md
@@ -124,12 +124,13 @@ By default, the software will run on HTTP using port 80. However, we recommend u
 cp docker-compose.override.yml.dist docker-compose.override.yml
 cp .ebextensions/ssl.config.dist .ebextensions/ssl.config
 cp ../../../../configs/letsencrypt/init-letsencrypt.sh .
+cp .platform/hooks/postdeploy/01_setup_ssl.sh.dist .platform/hooks/postdeploy/01_setup_ssl.sh 
 ```
 * Inside `.ebextensions/options.config` add a new environment variable:
 ```dotenv
 DOMAIN_NAME: example.com
 ```
-* Inside `.ebextensions/ssl.config` update the domain names and email address:
+* Inside `.platform/hooks/postdeploy/01_setup_ssl.sh` update the domain names and email address:
 ```shell
 sh init-letsencrypt.sh --email user@company.com --data_path /supportpal/ssl/certbot -- example.com www.example.com
 ```


### PR DESCRIPTION
* Moves running lets-encrypt ssl certificates generation from `container_commands` which runs after setting up the file, but before deployment to `postdeploy hooks` which happens after the deployment.