### PR TITLE
Drop support for Ubuntu 16

### DIFF
--- a/.github/workflows/linux-install.yml
+++ b/.github/workflows/linux-install.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           - centos:7
           - centos:8
-          - ubuntu:16.04
           - ubuntu:18.04
           - ubuntu:20.04
           - debian:9

--- a/templates/linux/Makefile
+++ b/templates/linux/Makefile
@@ -1,4 +1,4 @@
-TEST_IMAGE?=ubuntu:16.04
+TEST_IMAGE?=ubuntu:18.04
 
 WORK_DIR="/supportpal"
 VOLUME_MOUNTS=-v "$(CURDIR):$(WORK_DIR)"

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -5,7 +5,7 @@ version="0.0.1"
 
 supported="The following Linux OSs are supported, on x86_64 only:
     * RHEL/CentOS 7 & 8 (rhel)
-    * Ubuntu 16.04 LTS (xenial), 18.04 LTS (bionic), & 20.04 LTS (focal)
+    * Ubuntu 18.04 LTS (bionic), & 20.04 LTS (focal)
     * Debian 9 (stretch) & 10 (buster)"
 
 usage="Usage: curl -LsS https://raw.githubusercontent.com/supportpal/helpdesk-install/master/templates/linux/setup.sh | sudo bash


### PR DESCRIPTION
Canonical, the company behind Ubuntu, announced that the Ubuntu 16.04 LTS (Long Term Support) period will end on Friday, April 30, 2021 [1].