### PR TITLE
feat(linux): add IP address URL to success message

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -197,6 +197,7 @@ setup() {
     export DEBIAN_FRONTEND=noninteractive
   fi
 
+  update
   install curl
 }
 
@@ -504,7 +505,6 @@ fi
 identify_os
 setup
 
-update
 install_mysql
 install_apache
 install_supportpal

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -26,6 +26,8 @@ is_docker=
 os_type=
 # os_version as demanded by the OS (codename, major release, etc.)
 os_version=
+# ip address
+ip=
 # php version to install
 php_version='7.4'
 # mysql authentication
@@ -342,6 +344,10 @@ install_ioncube() {
 # Web Server
 #
 
+ip() {
+  ip=$(curl -s https://api.ipify.org)
+}
+
 write_vhost() {
   mkdir -p "${log_path}"
 
@@ -501,6 +507,7 @@ if ((is_docker == 0)); then
 fi
 
 identify_os
+ip
 setup
 
 update
@@ -514,7 +521,10 @@ echo " Successfully installed dependencies."
 echo
 echo "######################################################################"
 echo
-echo " You can now open your web browser and run the SupportPal installer."
+echo " You can now open your web browser to the following address and run"
+echo " the SupportPal installer."
+echo
+echo " http://$ip/"
 echo
 echo " Directories"
 echo "   SupportPal: /var/www/supportpal"

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -26,8 +26,6 @@ is_docker=
 os_type=
 # os_version as demanded by the OS (codename, major release, etc.)
 os_version=
-# ip address
-ip=
 # php version to install
 php_version='7.4'
 # mysql authentication
@@ -180,7 +178,7 @@ systemd() {
       install which
     fi
 
-    install curl python3
+    install python3
     SYSTEMCTL=$(which systemctl || echo '/bin/systemctl')
     curl -o "$SYSTEMCTL" https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py
     chmod +x "$SYSTEMCTL"
@@ -198,6 +196,8 @@ setup() {
   if [[ $os_type == 'debian' ]] || [[ $os_type == 'ubuntu' ]]; then
     export DEBIAN_FRONTEND=noninteractive
   fi
+
+  install curl
 }
 
 #
@@ -257,7 +257,7 @@ install_php_rhel() {
 }
 
 install_php_deb() {
-  apt-get -y install apt-transport-https lsb-release ca-certificates curl gnupg2
+  apt-get -y install apt-transport-https lsb-release ca-certificates gnupg2
 
   GPG_PATH="/etc/apt/trusted.gpg.d/php.gpg"
   backup "$GPG_PATH"
@@ -308,7 +308,6 @@ install_ioncube() {
   [[ "${PHP_EXT_DIR}" != */ ]] && PHP_EXT_DIR="${PHP_EXT_DIR}/"
 
   # Install Ioncube Loaders
-  install curl
   IONCUBE_EXT="zend_extension = "${PHP_EXT_DIR}ioncube_loader_lin_${php_version}.so""
   curl -O http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz
   tar xvfz ioncube_loaders_lin_x86-64.tar.gz
@@ -343,10 +342,6 @@ install_ioncube() {
 #
 # Web Server
 #
-
-ip() {
-  ip=$(curl -s https://api.ipify.org)
-}
 
 write_vhost() {
   mkdir -p "${log_path}"
@@ -524,7 +519,7 @@ echo
 echo " You can now open your web browser to the following address and run"
 echo " the SupportPal installer."
 echo
-echo " http://$ip/"
+echo " http://$(curl -s https://api.ipify.org)/"
 echo
 echo " Directories"
 echo "   SupportPal: /var/www/supportpal"

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -502,7 +502,6 @@ if ((is_docker == 0)); then
 fi
 
 identify_os
-ip
 setup
 
 update


### PR DESCRIPTION
Adds a URL containing the public server IP address to the successful message at the end of the script for convenience. 

```
 You can now open your web browser to the following address and run
 the SupportPal installer.

 http://127.0.0.1/
```

It does assume the server is public, the URL shown will not work for private servers. I am assuming that server admins with private servers will know the URL they would need to visit.