### PR TITLE
fix(linux): php-fpm address already in use on rhel 8.3

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -206,7 +206,7 @@ setup() {
 #
 
 configure_php_fpm() {
-  mkdir -p "$(dirname "$socket_path")" && touch "$socket_path"
+  mkdir -p "$(dirname "$socket_path")"
 
   echo "[supportpal]
 


### PR DESCRIPTION
Closes #7 
