### PR TITLE
chore: add DOMAIN_NAME parameter to .env.dist

### DIFF
--- a/templates/docker-compose/.env.dist
+++ b/templates/docker-compose/.env.dist
@@ -32,6 +32,7 @@ HOST=example.com
 # Misc
 APP_VERSION=3.3.1
 MAILTO=example@supportpal.com
+DOMAIN_NAME=example.com
 
 # Secrets
 SECRETS_DIR=${PWD}/secrets/


### PR DESCRIPTION
Rather than asking them to insert `DOMAIN_NAME` to .env, we can have it there so it's easier to set.