### PR TITLE
Add bash script to install via docker-compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v2
+            - name: Shellcheck
+              run: |
+                docker run --rm \
+                  -v "${PWD}:/v"  \
+                  -w "/v" \
+                  koalaman/shellcheck \
+                  -e SC1091 -e SC1117 \
+                  setup.sh
+              working-directory: templates/docker-compose
             - name: self-managed
               run: cp templates/docker-compose/.env.dist templates/docker-compose/.env && docker-compose -f templates/docker-compose/docker-compose.yml.dist -f templates/docker-compose/docker-compose.prod.yml.dist -f templates/docker-compose/docker-compose.override.yml.dist config
             - name: Single

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+set -eu -o pipefail
+
+usage="Usage: curl -LsS https://raw.githubusercontent.com/supportpal/helpdesk-install/master/templates/docker-compose/setup.sh | bash
+
+Options:
+    -h,--help                  Display this help and exit.
+
+    -n                         Run the command non interactively.
+
+    -H,--host=                 Domain name to use with SupportPal.
+
+    -e,--email=                System administrator email address to receive cron notifications.
+"
+
+# Options
+interactive=1
+host=
+email=
+
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+  -h|--help) echo "$usage" ; exit 0 ;;
+  -n) interactive=0 ;;
+  -H|--host) host="$2" ; shift ;;
+  -e|--email) email="$2" ; shift ;;
+  *)
+    echo "Unknown parameter passed: $1"
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+# usage: check_command <path>
+check_command() {
+  local _binary="$1" _full_path
+
+  printf "checking for %s ... " "$_binary"
+
+  # Checks if the binary is available.
+  _full_path="$(command -v "$_binary")"
+  _command_status="$?"
+  if [ "$_command_status" -ne 0 ]; then
+    printf "no\n"
+
+    return 1
+  else
+    printf "found %s\n" "$_full_path"
+
+    return 0
+  fi
+}
+
+# usage: version_ge <installed_version> <minimum_version>
+version_ge()
+{
+  if ! [ "$(printf '%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]; then
+    printf "error: %s is less than minimum required version of %s\n" "$1" "$2"
+    exit 1
+  fi
+}
+
+check_docker() {
+  if ! check_command docker; then
+    printf "error: Install docker using the official installation instructions: https://docs.docker.com/engine/install/\n"
+    exit 1
+  fi
+
+  local min="19.0.3" version
+
+  set +e
+  version="$(docker version -f "{{.Server.Version}}" 2>&1)"
+  command_status="$?"
+  set -e
+
+  if [ $command_status -ne 0 ]; then
+    echo "$version"
+
+    if [[ "$version" == *"permission denied"* ]]; then
+      echo
+      echo "You may need to add your user to the docker group and then logout/login again for the change to take effect:"
+      printf "\tsudo usermod -aG docker %s\n" "$USER"
+      echo
+      echo "Alternatively, consider installing rootless: https://docs.docker.com/engine/security/rootless/"
+    fi
+    exit 1
+  fi
+
+  printf "checking docker version %s >= %s ...\n" "$version" "$min"
+  version_ge "$version" "$min"
+}
+
+check_docker_compose() {
+  if ! check_command docker-compose; then
+    printf "error: Install docker-compose using the official installation instructions: https://docs.docker.com/compose/install/\n"
+    exit 1
+  fi
+
+  local min="1.24.0" version
+
+  version="$(docker-compose version --short)"
+  printf "checking docker-compose version %s >= %s ...\n" "$version" "$min"
+  version_ge "$version" "$min"
+}
+
+check_git() {
+  if ! check_command git; then
+    printf "error: Install git using the official installation instructions: https://git-scm.com/downloads\n"
+    exit 1
+  fi
+}
+
+check_make() {
+  if ! check_command make; then
+    printf "error: Install make for your distro.\n"
+    printf "       CentOS / RHEL: sudo yum install make -y\n"
+    printf "       Debian / Ubuntu: sudo apt install make -y\n"
+    exit 1
+  fi
+}
+
+escape_re() {
+  IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's/[&/\]/\\&/g; s/\n/\\&/g' <<<"$1")
+  printf %s "${REPLY%$'\n'}"
+}
+
+configure() {
+  git clone https://github.com/supportpal/helpdesk-install.git
+  cd helpdesk-install/templates/docker-compose
+
+  cp .env.dist .env
+  cp Makefile.dist Makefile
+
+  if [ "$interactive" -eq 1 ]; then
+    echo
+    echo "Enter system administrator email address."
+    echo "This will notify you if there's a problem with the cron and allow you to take corrective action."
+    read -r email
+
+    echo
+    echo "Enter system domain name. Leave blank to configure later..."
+    read -r host
+  fi
+
+  if [[ -n "${email// }" ]]; then
+    sed -i -E "s/^(MAILTO=).*/\1$(escape_re "${email// }")/" .env
+    printf "wrote 'MAILTO=%s' to .env\n" "${email// }"
+  fi
+
+  if [[ -n "${host// }" ]]; then
+    sed -i -E "s/^(HOST=).*/\1$(escape_re "${host// }")/" .env
+    printf "wrote 'HOST=%s' to .env\n" "${host// }"
+
+    sed -i -E "s/^(DOMAIN_NAME=).*/\1$(escape_re "${host// }")/" .env
+    printf "wrote 'DOMAIN_NAME=%s' to .env\n" "${host// }"
+  fi
+}
+
+check_docker
+check_docker_compose
+check_git
+check_make
+
+configure
+make install

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -107,7 +107,7 @@ configure_windows() {
   if [[ ! -e "${path}" ]]; then
     printf "registering winpty aliases ...\n"
 
-    mkdir -p "${path}"
+    mkdir -p "$(dirname "${path}")"
     echo "alias docker='winpty docker'" >> "${path}"
 
     echo "[ -f ${path} ] && . ${path}" >> ~/.bashrc

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -eu -o pipefail
 
-usage="Usage: curl -LsS https://raw.githubusercontent.com/supportpal/helpdesk-install/master/templates/docker-compose/setup.sh | bash
+usage="Usage (Linux): curl -LsS https://raw.githubusercontent.com/supportpal/helpdesk-install/master/templates/docker-compose/setup.sh | bash
+
+Usage (Windows / Git Bash): winpty bash <(curl -LsS https://raw.githubusercontent.com/supportpal/helpdesk-install/master/templates/docker-compose/setup.sh)
 
 Options:
     -h,--help                  Display this help and exit.

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -32,6 +32,23 @@ while [[ "$#" -gt 0 ]]; do
   shift
 done
 
+os_type=
+identify_os() {
+  # Check for RHEL/CentOS, Fedora, etc.
+  if command -v rpm >/dev/null && [[ -e /etc/redhat-release ]]; then
+    os_type=rhel
+  elif [[ -e /etc/os-release ]]; then
+    . /etc/os-release
+    # Is it Debian?
+    case $ID in
+    debian)
+      os_type=debian ;;
+    ubuntu)
+      os_type=ubuntu ;;
+    esac
+  fi
+}
+
 # usage: check_command <path>
 check_command() {
   local _binary="$1" _full_path
@@ -114,8 +131,13 @@ check_git() {
 check_make() {
   if ! check_command make; then
     printf "error: Install make for your distro.\n"
-    printf "       CentOS / RHEL: sudo yum install make -y\n"
-    printf "       Debian / Ubuntu: sudo apt install make -y\n"
+
+    if [[ $os_type == 'rhel' ]]; then
+      printf "       sudo yum install make -y\n"
+    elif [[ $os_type == 'debian' ]] || [[ $os_type == 'ubuntu' ]]; then
+      printf "       sudo apt install make -y\n"
+    fi
+
     exit 1
   fi
 }
@@ -157,6 +179,7 @@ configure() {
   fi
 }
 
+identify_os
 check_docker
 check_docker_compose
 check_git

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -60,7 +60,7 @@ identify_os() {
   fi
 }
 
-# usage: check_command <path>
+# usage: check_command <bashrc__full_path>
 check_command() {
   local _binary="$1" _full_path
 
@@ -103,14 +103,19 @@ configure_windows() {
   check_winpty
 
   # winpty is required to run docker interactively (create a tty).
-  aliases="alias docker='winpty docker'"
-  if [[ ! -e ~/.bashrc ]] || [[ $(grep -L "${aliases}" ~/.bashrc) ]]; then
-    printf "registering winpty aliases to ... %s %s\n" ~/.bashrc ~/.bash_profile
-    echo "${aliases}" >> ~/.bashrc
-    echo "[ -f ~/.bashrc ] && . ~/.bashrc" >> ~/.bash_profile
+  path="${HOME}/.winpty/supportpal.sh"
+  if [[ ! -e "${path}" ]]; then
+    printf "registering winpty aliases ...\n"
+
+    mkdir -p "${path}"
+    echo "alias docker='winpty docker'" >> "${path}"
+
+    echo "[ -f ${path} ] && . ${path}" >> ~/.bashrc
+    echo "[ -f ${path} ] && . ${path}" >> ~/.bash_profile
   fi
-  
-  source ~/.bash_profile
+
+  # shellcheck disable=SC1090
+  . "${path}"
 }
 
 check_docker() {

--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -222,6 +222,6 @@ check_docker
 check_docker_compose
 check_git
 check_make
-
+echo
 configure
 make install


### PR DESCRIPTION
## Introduction

The purpose of this script is to check the correct versions of prerequisites currently listed on https://docs.supportpal.com/current/Deploy+on+Docker are installed. It gives some helpful tips when things are missing or the appropriate version is installed.

It also has interactive and non-interactive mode which handles the [ConfigureDockerCompose](https://docs.supportpal.com/current/Deploy+on+Docker#ConfigureDockerCompose) steps.

## Example runs

Missing docker:
```
$ bash setup.sh 
checking for docker ... found /usr/bin/docker

Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Get http://%2Fvar%2Frun%2Fdocker.sock/v1.24/version: dial unix /var/run/docker.sock: connect: permission denied

You may need to add your user to the docker group and then logout/login again for the change to take effect:
	sudo usermod -aG docker ubuntu

Alternatively, consider installing rootless: https://docs.docker.com/engine/security/rootless/

```

Missing docker-compose:
```
$ bash setup.sh 
checking for docker ... found /usr/bin/docker
checking docker version 20.10.6 >= 19.0.3 ...
checking for docker-compose ... no
error: Install docker-compose using the official installation instructions: https://docs.docker.com/compose/install/

```

Missing make:
```
$ bash setup.sh 
checking for docker ... found /usr/bin/docker
checking docker version 20.10.6 >= 19.0.3 ...
checking for docker-compose ... found /usr/local/bin/docker-compose
checking docker-compose version 1.29.1 >= 1.24.0 ...
checking for git ... found /usr/bin/git
checking for make ... no
error: Install make for your distro.
       CentOS / RHEL: sudo yum install make -y
       Debian / Ubuntu: sudo apt install make -y

```

Using non-interactive mode:
```
$ bash setup.sh -n -H test.com -e foo@bar
checking for docker ... found /usr/bin/docker
checking docker version 20.10.6 >= 19.0.3 ...
checking for docker-compose ... found /usr/local/bin/docker-compose
checking docker-compose version 1.29.1 >= 1.24.0 ...
checking for git ... found /usr/bin/git
checking for make ... found /usr/bin/make
Cloning into 'helpdesk-install'...
remote: Enumerating objects: 525, done.
remote: Counting objects: 100% (186/186), done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 525 (delta 158), reused 130 (delta 124), pack-reused 339
Receiving objects: 100% (525/525), 1.25 MiB | 7.14 MiB/s, done.
Resolving deltas: 100% (278/278), done.
wrote 'MAILTO=foo@bar' to .env
wrote 'HOST=test.com' to .env
wrote 'DOMAIN_NAME=test.com' to .env
cp -n .env.dist .env || true
[...]
```

Using interactive mode:
```
$ bash setup.sh 
checking for docker ... found /usr/bin/docker
checking docker version 20.10.6 >= 19.0.3 ...
checking for docker-compose ... found /usr/local/bin/docker-compose
checking docker-compose version 1.29.1 >= 1.24.0 ...
checking for git ... found /usr/bin/git
checking for make ... found /usr/bin/make
Cloning into 'helpdesk-install'...
remote: Enumerating objects: 525, done.
remote: Counting objects: 100% (186/186), done.
remote: Compressing objects: 100% (61/61), done.
remote: Total 525 (delta 158), reused 130 (delta 124), pack-reused 339
Receiving objects: 100% (525/525), 1.25 MiB | 6.03 MiB/s, done.
Resolving deltas: 100% (278/278), done.

Enter system administrator email address.
This will notify you if there's a problem with the cron and allow you to take corrective action.
foo@bar

Enter system domain name. Leave blank to configure later...
test.com
wrote 'MAILTO=foo@bar' to .env
wrote 'HOST=test.com' to .env
wrote 'DOMAIN_NAME=test.com' to .env
cp -n .env.dist .env || true

```

Git directory already exists:
```
 bash setup.sh 
checking for docker ... found /usr/bin/docker
checking docker version 20.10.6 >= 19.0.3 ...
checking for docker-compose ... found /usr/local/bin/docker-compose
checking docker-compose version 1.29.1 >= 1.24.0 ...
checking for git ... found /usr/bin/git
checking for make ... found /usr/bin/make
fatal: destination path 'helpdesk-install' already exists and is not an empty directory.
```