### PR TITLE
chore: remove pwd and replace with docker-compose .

### DIFF
--- a/templates/docker-compose/.env.dist
+++ b/templates/docker-compose/.env.dist
@@ -35,4 +35,4 @@ MAILTO=example@supportpal.com
 DOMAIN_NAME=example.com
 
 # Secrets
-SECRETS_DIR=${PWD}/secrets/
+SECRETS_DIR=./secrets/

--- a/templates/docker-compose/.env.dist
+++ b/templates/docker-compose/.env.dist
@@ -35,4 +35,5 @@ MAILTO=example@supportpal.com
 DOMAIN_NAME=example.com
 
 # Secrets
+CONFIGURATOR_VERSION=latest
 SECRETS_DIR=./secrets/

--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -60,7 +60,7 @@ create_volumes:
 
 .PHONY: create_secrets
 create_secrets:
-	$(DOCKER_COMPOSE_BIN) -f docker-compose.secrets.yml up
+	$(DOCKER_COMPOSE_BIN) -f docker-compose.secrets.yml up --force-recreate
 
 .PHONY: configure
 configure:

--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -60,11 +60,12 @@ create_volumes:
 
 .PHONY: create_secrets
 create_secrets:
-	$(DOCKER_BIN) run -e SECRETS_DIR="$(SECRETS_DIR)" -v "$(SECRETS_DIR):/secrets" "public.ecr.aws/supportpal/helpdesk-configurator:$(CONFIGURATOR_VERSION)" sh "//app//scripts//create_secrets.sh"
+	$(DOCKER_COMPOSE_BIN) -f docker-compose.secrets.yml up
 
 .PHONY: configure
 configure:
 	cp -n .env.dist .env || true
+	cp -n docker-compose.secrets.yml.dist docker-compose.secrets.yml || true
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	cp -n docker-compose.prod.yml.dist docker-compose.prod.yml || true
 	cp -n -R ../../configs/gateway . || true

--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -59,7 +59,7 @@ create_volumes:
 
 .PHONY: create_secrets
 create_secrets:
-	$(DOCKER_COMPOSE_BIN) -f docker-compose.secrets.yml up --force-recreate
+	$(DOCKER_COMPOSE_BIN) -f docker-compose.secrets.yml run --rm -T configurator
 
 .PHONY: configure
 configure:

--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -4,7 +4,6 @@ include .env
 
 DOCKER_BIN=docker
 DOCKER_COMPOSE_BIN=docker-compose
-CONFIGURATOR_VERSION=latest
 COMPOSE_FILES=-f docker-compose.yml -f docker-compose.prod.yml
 
 .DEFAULT_GOAL := help

--- a/templates/docker-compose/docker-compose.secrets.yml.dist
+++ b/templates/docker-compose/docker-compose.secrets.yml.dist
@@ -7,4 +7,5 @@ services:
             SECRETS_DIR: ${SECRETS_DIR}
         volumes:
             - ${SECRETS_DIR}:/secrets/
+        network_mode: "bridge"
         command: 'sh /app/scripts/create_secrets.sh'

--- a/templates/docker-compose/docker-compose.secrets.yml.dist
+++ b/templates/docker-compose/docker-compose.secrets.yml.dist
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     configurator:
-        image: public.ecr.aws/supportpal/helpdesk-configurator:latest
+        image: public.ecr.aws/supportpal/helpdesk-configurator:${CONFIGURATOR_VERSION}
         environment:
             SECRETS_DIR: ${SECRETS_DIR}
         volumes:

--- a/templates/docker-compose/docker-compose.secrets.yml.dist
+++ b/templates/docker-compose/docker-compose.secrets.yml.dist
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+    configurator:
+        image: public.ecr.aws/supportpal/helpdesk-configurator:latest
+        environment:
+            SECRETS_DIR: ${SECRETS_DIR}
+        volumes:
+            - ${SECRETS_DIR}:/secrets/
+        command: 'sh /app/scripts/create_secrets.sh'


### PR DESCRIPTION
### Background

`$PWD` was used to allow usage in dev environments where we're mixing multiple `docker-compose.yml` files which exist in different directories. 

### Motivation

`$PWD` variable is not available on all shells/environments. 

### Resolution

Relative path support is missing from `docker` cli (`https://github.com/docker/cli/issues/1203`). So, this PR replaces docker cli `$PWD` usages with `docker-compose` which has relative path support (`.` notation).
> You can mount a relative path on the host, which expands relative to the directory of the Compose configuration file being used. Relative paths should always begin with `.` or `..`.
https://docs.docker.com/compose/compose-file/compose-file-v3/