### PR TITLE
Provide DB details to docker installer

### DIFF
--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -15,7 +15,7 @@ help:
 install: configure create_secrets create_volumes ## Install the helpdesk.
 	$(DOCKER_COMPOSE_BIN) $(COMPOSE_FILES) up -d gateway supportpal db redis
 	$(DOCKER_BIN) exec $(DATABASE_SERVICE_NAME) bash -c "while ! (mysqladmin ping -uroot -p$$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
-	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$$(cat secrets/db_user.txt) --db-pass=$$(cat secrets/db_password.txt) --db-name=supportpal"
+	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$$(cat $(SECRETS_DIR)db_user.txt) --db-pass=$$(cat $(SECRETS_DIR)db_password.txt) --db-name=supportpal"
 
 .PHONY: start
 start: ## Start the help desk.

--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -11,13 +11,11 @@ COMPOSE_FILES=-f docker-compose.yml -f docker-compose.prod.yml
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(SELF_FILENAME) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: install_cli
-install_cli: install_base ## Install the help desk using the CLI installer.
-	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c '/usr/local/bin/php artisan app:install'
-
 .PHONY: install
-install: install_base ## Install the helpdesk using the web installer.
-	@printf "Open your web browser and complete the installation using the above database details.\n"
+install: configure create_secrets create_volumes ## Install the helpdesk.
+	$(DOCKER_COMPOSE_BIN) $(COMPOSE_FILES) up -d gateway supportpal db redis
+	$(DOCKER_BIN) exec $(DATABASE_SERVICE_NAME) bash -c "while ! (mysqladmin ping -uroot -p$$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
+	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$$(cat secrets/db_user.txt) --db-pass=$$(cat secrets/db_password.txt) --db-name=supportpal"
 
 .PHONY: start
 start: ## Start the help desk.
@@ -68,18 +66,6 @@ configure:
 	cp -n docker-compose.yml.dist docker-compose.yml || true
 	cp -n docker-compose.prod.yml.dist docker-compose.prod.yml || true
 	cp -n -R ../../configs/gateway . || true
-
-.PHONY: install_base
-install_base: configure create_secrets create_volumes
-	$(DOCKER_COMPOSE_BIN) $(COMPOSE_FILES) up -d gateway supportpal db redis
-	@echo
-	@printf "Database Configuration:\n"
-	@printf "\tHostname: db\n"
-	@printf "\tPort: 3306\n"
-	@printf "\tDatabase: supportpal\n"
-	@printf "\tUsername: $$(cat secrets/db_user.txt)\n"
-	@printf "\tPassword: $$(cat secrets/db_password.txt)\n"
-	@echo
 
 .PHONY: upgrade
 upgrade: ## Upgrade SupportPal to a later version.


### PR DESCRIPTION
This PR switches the `docker-compose` template to use the SupportPal CLI installer. helpdesk#2620 was added in v3.5.0 and allows us to feed in the database details rather than the user having to provide them.

> helpdesk#2620 | Added app:install options to pass database details non-interactively.

https://docs.supportpal.com/current/3.5.0 

----

The `mysqladmin ping` was necessary as `app:install` immediately validates the provided database details. It returns `Connection refused` if you don't wait for MySQL to be fully up.