### PR TITLE
Fix connection refused in docker-compose install

### DIFF
--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -14,7 +14,7 @@ help:
 .PHONY: install
 install: configure create_secrets create_volumes ## Install the helpdesk.
 	$(DOCKER_COMPOSE_BIN) $(COMPOSE_FILES) up -d gateway supportpal db redis
-	$(DOCKER_BIN) exec $(DATABASE_SERVICE_NAME) bash -c "while ! (mysqladmin ping -uroot -p$$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
+	$(DOCKER_BIN) exec $(WEB_SERVICE_NAME) bash -c "while ! (mysqladmin ping -h db -uroot -p$$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
 	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$$(cat $(SECRETS_DIR)db_user.txt) --db-pass=$$(cat $(SECRETS_DIR)db_password.txt) --db-name=supportpal"
 
 .PHONY: start


### PR DESCRIPTION
```
docker exec db bash -c "while ! (mysqladmin ping -uroot -p$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
mysqladmin: [Warning] Using a password on the command line interface can be insecure.
docker exec -it -u www-data supportpal bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$(cat ./secrets/db_user.txt) --db-pass=$(cat ./secrets/db_password.txt) --db-name=supportpal"
+--------------------------------------------+
|
| SupportPal Installer - 3.5.0
|
+--------------------------------------------+
Please read our software license agreement below. By continuing, you are agreeing to the license.
https://www.supportpal.com/company/eula
 I Accept and Continue (yes/no) [no]:
 > yes
There was an error. You may need to empty the database before starting again.
SQLSTATE[HY000] [2002] Connection refused
make: *** [Makefile:18: install] Error 1
```

The above log shows that MySQL initialised but docker hasn't opened port 3306 on the `db` container, so the `supportpal` container cannot connect.

This PR waits until the `supportpal` container can communicate with the `db` container before continuing.