### PR TITLE
feat: add gzip to nginx config

### DIFF
--- a/configs/gateway/nginx-http.conf
+++ b/configs/gateway/nginx-http.conf
@@ -4,6 +4,14 @@ server {
 
     server_name _;
 
+    # enable gzip
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 500;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/javascript application/json application/javascript;
+    gzip_vary on;
+
     # add security headers
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-Content-Type-Options nosniff always;

--- a/configs/gateway/nginx-https.conf
+++ b/configs/gateway/nginx-https.conf
@@ -21,8 +21,18 @@ server {
     listen [::]:443 default_server;
 
     server_name _;
+
+    #add SSL configuration
     ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
+
+    # enable gzip
+    gzip on;
+    gzip_comp_level 6;
+    gzip_min_length 500;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/javascript application/json application/javascript;
+    gzip_vary on;
 
     # add security headers
     add_header X-Frame-Options SAMEORIGIN always;


### PR DESCRIPTION
This PR enables Gzip compression to our Nginx configuration. Most notably, the customizations are done due to the following reasons:

- gzip_types are chosen based on a quick lookup on what we use inside the software

- gzip_comp_level, among other sources, level 6 is chosen based on this [discussion](https://www.rootusers.com/gzip-vs-bzip2-vs-xz-performance-comparison/).  The main reason is that it seems to - on average - have the best compression to resources usage ratio

- gzip_min_length, there isn't much discussion or benchmarks for min_length but most configurations use either 500, or 1000. This is because the default is too low (a 20byte file won't be compressed much anyways)

- gzip_proxied enable compression across all proxies