### PR TITLE
fix(linux): unable to download latest SupportPal version

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -480,8 +480,9 @@ install_mysql() {
 
 install_supportpal() {
   install jq unzip
-  SP_VERSION=$(curl -s https://licensing.supportpal.com/api/version/latest.json | jq -r ".version")
-  curl "https://www.supportpal.com/manage/downloads/supportpal-$SP_VERSION.zip" -o /tmp/supportpal.zip
+  URLS=$( curl -sL https://licensing.supportpal.com/api/version/available.json | jq -r '.version[].artifacts[].download_url' | tr '\n' ' ')
+  DOWNLOAD_URL=$(echo "$URLS" | grep ".zip" | cut -d' ' -f1)
+  curl "${DOWNLOAD_URL}" -o /tmp/supportpal.zip
   unzip /tmp/supportpal.zip -d "${install_path}"
   rm /tmp/supportpal.zip
 


### PR DESCRIPTION
Linux command currently produces:
````
Archive:  /tmp/supportpal.zip
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /tmp/supportpal.zip or
        /tmp/supportpal.zip.zip, and cannot find /tmp/supportpal.zip.ZIP, period.
````

This is due to public access to `supportpal.com/manage/downloads/` being recently blocked.

Download URLs are now accessible from the license server.