### PR TITLE
refactor(docker): nginx config

### DIFF
--- a/configs/gateway/base.conf
+++ b/configs/gateway/base.conf
@@ -1,0 +1,40 @@
+# this path MUST be exactly as docker-compose.fpm.volumes,
+# even if it doesn't exist in this dock.
+root /supportpal;
+index index.php;
+
+# Hide Nginx version
+server_tokens off;
+
+# Remove index.php from GET requests.
+set $user_request 0;
+if ($request_method = GET) {
+    set $user_request "GET";
+}
+if ($request_uri ~* "^(.*/)index\.php/?(.*)$") {
+    set $user_request "${user_request}-index.php";
+}
+if ($user_request = "GET-index.php") {
+    return 301 $scheme://$http_host$1$2;
+}
+
+# Send all requests to SupportPal.
+location / {
+    try_files /notexistent @backend;
+}
+
+# Allow direct access to asset files, if they don't exist show SupportPal 404 error page.
+location ~* \.(css|gif|ico|je?pg|js|png|swf|txt|eot|ttf|woff|woff2|svg|map|webmanifest)$ {
+    try_files $uri $uri/ @backend;
+}
+
+# Allow direct access to resources/assets files, if they don't exist show SupportPal 404 error page.
+location resources/assets/ {
+    try_files $uri $uri/ @backend;
+}
+
+# All SupportPal requests must be sent through index.php.
+location @backend {
+    rewrite ^(.*)$ /index.php last;
+}
+

--- a/configs/gateway/custom.conf
+++ b/configs/gateway/custom.conf
@@ -1,0 +1,18 @@
+# enable gzip
+gzip on;
+gzip_comp_level 6;
+gzip_min_length 500;
+gzip_proxied any;
+gzip_types text/plain text/css text/javascript application/json application/javascript;
+gzip_vary on;
+
+# add security headers
+add_header X-Frame-Options SAMEORIGIN always;
+add_header X-Content-Type-Options nosniff always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy strict-origin-when-cross-origin always;
+add_header Strict-Transport-Security max-age=31536000 always;
+
+# disable request entity max size.
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+client_max_body_size 0;

--- a/configs/gateway/nginx-http.conf
+++ b/configs/gateway/nginx-http.conf
@@ -4,64 +4,7 @@ server {
 
     server_name _;
 
-    # enable gzip
-    gzip on;
-    gzip_comp_level 6;
-    gzip_min_length 500;
-    gzip_proxied any;
-    gzip_types text/plain text/css text/javascript application/json application/javascript;
-    gzip_vary on;
-
-    # add security headers
-    add_header X-Frame-Options SAMEORIGIN always;
-    add_header X-Content-Type-Options nosniff always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Strict-Transport-Security max-age=31536000 always;
-
-    # disable request entity max size.
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-    client_max_body_size 0;
-
-    # this path MUST be exactly as docker-compose.fpm.volumes,
-    # even if it doesn't exist in this dock.
-    root /supportpal;
-    index index.php;
-
-    # Hide Nginx version
-    server_tokens off;
-
-    # Remove index.php from GET requests.
-    set $user_request 0;
-    if ($request_method = GET) {
-        set $user_request "GET";
-    }
-    if ($request_uri ~* "^(.*/)index\.php/?(.*)$") {
-        set $user_request "${user_request}-index.php";
-    }
-    if ($user_request = "GET-index.php") {
-        return 301 $scheme://$http_host$1$2;
-    }
-
-    # Send all requests to SupportPal.
-    location / {
-        try_files /notexistent @backend;
-    }
-
-    # Allow direct access to asset files, if they don't exist show SupportPal 404 error page.
-    location ~* \.(css|gif|ico|je?pg|js|png|swf|txt|eot|ttf|woff|woff2|svg|map|webmanifest)$ {
-        try_files $uri $uri/ @backend;
-    }
-
-    # Allow direct access to resources/assets files, if they don't exist show SupportPal 404 error page.
-    location resources/assets/ {
-        try_files $uri $uri/ @backend;
-    }
-
-    # All SupportPal requests must be sent through index.php.
-    location @backend {
-        rewrite ^(.*)$ /index.php last;
-    }
+    include /etc/nginx/conf.d/*.config;
 
     location ~ \.php($|/) {
         fastcgi_pass ${WEB_CONTAINER}:9000;

--- a/configs/gateway/nginx-https.conf
+++ b/configs/gateway/nginx-https.conf
@@ -26,65 +26,7 @@ server {
     ssl_certificate /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem;
 
-    # enable gzip
-    gzip on;
-    gzip_comp_level 6;
-    gzip_min_length 500;
-    gzip_proxied any;
-    gzip_types text/plain text/css text/javascript application/json application/javascript;
-    gzip_vary on;
-
-    # add security headers
-    add_header X-Frame-Options SAMEORIGIN always;
-    add_header X-Content-Type-Options nosniff always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Strict-Transport-Security max-age=31536000 always;
-    add_header Content-Security-Policy upgrade-insecure-requests always;
-
-    # disable request entity max size.
-    # http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-    client_max_body_size 0;
-
-    # this path MUST be exactly as docker-compose.fpm.volumes,
-    # even if it doesn't exist in this dock.
-    root /supportpal;
-    index index.php;
-
-    # Hide Nginx version
-    server_tokens off;
-
-    # Remove index.php from GET requests.
-    set $user_request 0;
-    if ($request_method = GET) {
-        set $user_request "GET";
-    }
-    if ($request_uri ~* "^(.*/)index\.php/?(.*)$") {
-        set $user_request "${user_request}-index.php";
-    }
-    if ($user_request = "GET-index.php") {
-        return 301 $scheme://$http_host$1$2;
-    }
-
-    # Send all requests to SupportPal.
-    location / {
-        try_files /notexistent @backend;
-    }
-
-    # Allow direct access to asset files, if they don't exist show SupportPal 404 error page.
-    location ~* \.(css|gif|ico|je?pg|js|png|swf|txt|eot|ttf|woff|woff2|svg|map|webmanifest)$ {
-        try_files $uri $uri/ @backend;
-    }
-
-    # Allow direct access to resources/assets files, if they don't exist show SupportPal 404 error page.
-    location resources/assets/ {
-        try_files $uri $uri/ @backend;
-    }
-
-    # All SupportPal requests must be sent through index.php.
-    location @backend {
-        rewrite ^(.*)$ /index.php last;
-    }
+    include /etc/nginx/conf.d/*.config;
 
     location ~ \.php($|/) {
         fastcgi_pass ${WEB_CONTAINER}:9000;
@@ -92,5 +34,3 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }
 }
-
-

--- a/templates/aws/eb/HA/cron/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/cron/docker-compose.yml.dist
@@ -9,8 +9,8 @@ services:
             - supportpal_cron
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
-            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
-            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
+            - ./gateway/base.conf:/etc/nginx/templates/base.config.template
+            - ./gateway/custom.conf:/etc/nginx/templates/custom.config.template
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app:ro
         environment:

--- a/templates/aws/eb/HA/cron/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/cron/docker-compose.yml.dist
@@ -9,6 +9,8 @@ services:
             - supportpal_cron
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
+            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
+            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app:ro
         environment:

--- a/templates/aws/eb/HA/web/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/web/docker-compose.yml.dist
@@ -11,6 +11,8 @@ services:
             WEB_CONTAINER: ${WEB_SERVICE_NAME}
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
+            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
+            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app:ro
         ports:

--- a/templates/aws/eb/HA/web/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/web/docker-compose.yml.dist
@@ -11,8 +11,8 @@ services:
             WEB_CONTAINER: ${WEB_SERVICE_NAME}
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
-            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
-            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
+            - ./gateway/base.conf:/etc/nginx/templates/base.config.template
+            - ./gateway/custom.conf:/etc/nginx/templates/custom.config.template
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app:ro
         ports:

--- a/templates/aws/eb/Preview/docker-compose.yml.dist
+++ b/templates/aws/eb/Preview/docker-compose.yml.dist
@@ -11,8 +11,8 @@ services:
             - supportpal
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
-            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
-            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
+            - ./gateway/base.conf:/etc/nginx/templates/base.config.template
+            - ./gateway/custom.conf:/etc/nginx/templates/custom.config.template
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app
         ports:

--- a/templates/aws/eb/Preview/docker-compose.yml.dist
+++ b/templates/aws/eb/Preview/docker-compose.yml.dist
@@ -11,6 +11,8 @@ services:
             - supportpal
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
+            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
+            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app
         ports:

--- a/templates/aws/eb/Single/docker-compose.yml.dist
+++ b/templates/aws/eb/Single/docker-compose.yml.dist
@@ -9,8 +9,8 @@ services:
             - supportpal
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
-            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
-            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
+            - ./gateway/base.conf:/etc/nginx/templates/base.config.template
+            - ./gateway/custom.conf:/etc/nginx/templates/custom.config.template
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app
         environment:

--- a/templates/aws/eb/Single/docker-compose.yml.dist
+++ b/templates/aws/eb/Single/docker-compose.yml.dist
@@ -9,6 +9,8 @@ services:
             - supportpal
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
+            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
+            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
             - supportpal_resources:/supportpal/resources:ro
             - supportpal_app:/supportpal/app
         environment:

--- a/templates/docker-compose/docker-compose.yml.dist
+++ b/templates/docker-compose/docker-compose.yml.dist
@@ -11,6 +11,8 @@ services:
             WEB_CONTAINER: ${WEB_SERVICE_NAME}
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
+            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
+            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
         ports:
             - '${HTTP_REMOTE_PORT}:80'
         networks:

--- a/templates/docker-compose/docker-compose.yml.dist
+++ b/templates/docker-compose/docker-compose.yml.dist
@@ -11,8 +11,8 @@ services:
             WEB_CONTAINER: ${WEB_SERVICE_NAME}
         volumes:
             - ./gateway/nginx-http.conf:/etc/nginx/templates/default.conf.template
-            - ./gateway/base.conf:/etc/nginx/conf.d/base.config
-            - ./gateway/custom.conf:/etc/nginx/conf.d/custom.config
+            - ./gateway/base.conf:/etc/nginx/templates/base.config.template
+            - ./gateway/custom.conf:/etc/nginx/templates/custom.config.template
         ports:
             - '${HTTP_REMOTE_PORT}:80'
         networks:


### PR DESCRIPTION
This PR is a fresh attempt at https://github.com/supportpal/helpdesk-install/pull/47 which was subsequently reverted in https://github.com/supportpal/helpdesk-install/pull/49

The main benefit of this PR is that the duplication between `nginx-http.conf` and `nginx-https.conf` has been removed.

Users can modify all config files but are encouraged to make any additions in `custom.conf`