### PR TITLE
fix(linux): use pwgen to generate mysql passwords

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -235,7 +235,7 @@ setup() {
   fi
 
   update
-  install curl
+  install curl pwgen
 }
 
 #
@@ -453,7 +453,7 @@ install_apache() {
 #
 
 generate_password() {
-  openssl rand -base64 14
+  pwgen -1 -s -y -n -c -v 15
 }
 
 install_mysql() {


### PR DESCRIPTION
Fixes below issue on CentOS (rare occurrence):
```console
$ mysql --connect-expired*** '-p8F(z:*+A#=yb' -e 'ALTER USER '\''root'\''@'\''localhost'\'' IDENTIFIED WITH mysql_native_password BY '\''OtdmPAkjqoWFmVNhjwo='\''; FLUSH PRIVILEGES;'
Warning: arning] Using a password on the command line interface can be insecure.
ERROR 1819 (HY000) at line 1: Your password does not satisfy the current policy requirements
```
pwgen options:
* `-c or --capitalize` - Include at least one capital letter in the password
* `-n or --numerals` - Include at least one number in the password
*  `-y or --symbols` - Include at least one special symbol in the password
* `-s or --secure` - Generate completely random passwords
* `-1` - Don't print the generated passwords in columns
* `-v or --no-vowels` - Do not use any vowels so as to avoid accidental nasty words
* 15 characters long
