### PR TITLE
feat(linux): drop el7 support

### DIFF
--- a/.github/workflows/linux-verify.yml
+++ b/.github/workflows/linux-verify.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - centos:7
           - centos:8
           - ubuntu:18.04
           - ubuntu:20.04

--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -263,9 +263,6 @@ php_admin_value[log_errors] = on
 }
 
 install_php_rhel() {
-  # Remove . from php_version
-  local stripped_version=${php_version//\./}
-
   install_rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   install_rpm https://rpms.remirepo.net/enterprise/remi-release-8.rpm
   dnf -y module reset php && dnf -y module enable "php:remi-${php_version}"
@@ -334,9 +331,6 @@ install_ioncube() {
   cp "ioncube/ioncube_loader_lin_${php_version}.so" "${PHP_EXT_DIR}"
 
   if [[ $os_type == 'rhel' ]]; then
-    # Remove . from php_version
-    local stripped_version=${php_version//\./}
-
     INI_PATH="/etc/php.d/00-ioncube.ini"
     backup "$INI_PATH"
     echo "$IONCUBE_EXT" >"$INI_PATH"


### PR DESCRIPTION
`yum` is troublesome and requires dropping the error catching mode temporarily. EL8 should be used instead to reduce the main of different logic we need to maintain.