### PR TITLE
fix(linux): ensure mixed case password

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -469,9 +469,20 @@ install_apache() {
 #
 
 generate_password() {
-  # sudo only provides access to /sbin:/bin:/usr/sbin:/usr/bin
-  # commands in /usr/local/bin cannot be found (https://unix.stackexchange.com/a/8652).
-  /usr/local/bin/pwgen -1 -s -y -n -c -v -r \`\'\"\$\|\\ 15
+  local passwd
+
+  passwd=""
+
+  # it's possible for pwgen to generate strings that are single case
+  # strong passwords must be:
+  #     Length >= 8, numeric, mixed case, special characters and dictionary file
+  while [[ $passwd = "${passwd,,}" ]] || [[ $passwd = "${passwd^^}" ]]; do
+    # sudo only provides access to /sbin:/bin:/usr/sbin:/usr/bin
+    # commands in /usr/local/bin cannot be found (https://unix.stackexchange.com/a/8652).
+    passwd=$(/usr/local/bin/pwgen -1 -s -y -n -c -v -r \`\'\"\$\|\\ 15)
+  done
+
+  echo "${passwd}"
 }
 
 install_mysql() {


### PR DESCRIPTION
It's possible for pwgen to generate a string that is not mixed case:
```console
mysql --connect-expired*** '--***;IAbMt73:' -e 'ALTER USER '\''root'\''@'\''localhost'\'' IDENTIFIED WITH mysql_native_password BY '\''!?#T*^B~J}2^Z;{'\''; FLUSH PRIVILEGES;'
Warning: arning] Using a password on the command line interface can be insecure.
ERROR 1819 (HY000) at line 1: Your password does not satisfy the current policy requirements
```