### PR TITLE
feat(linux): permit https in firewall-cmd

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -393,7 +393,7 @@ install_apache_rhel() {
   install httpd firewalld
   systemd restart httpd && systemd enable httpd
   systemd restart firewalld && systemd enable firewalld
-  firewall-cmd --add-service=http --permanent && firewall-cmd --reload
+  firewall-cmd --add-service=http --add-service=https --permanent && firewall-cmd --reload
 
   backup /etc/httpd/conf.d/welcome.conf
 


### PR DESCRIPTION
Enable HTTPS in the firewall on CentOS 8. Saves the user the bother even though it's not setup yet. Apache isn't listening on port 443 by default so the port is closed.