### PR TITLE
feat(docker): run make restart after installation

### DIFF
--- a/templates/docker-compose/Makefile.dist
+++ b/templates/docker-compose/Makefile.dist
@@ -16,6 +16,7 @@ install: configure create_secrets create_volumes ## Install the helpdesk.
 	$(DOCKER_COMPOSE_BIN) $(COMPOSE_FILES) up -d gateway supportpal db redis
 	$(DOCKER_BIN) exec $(WEB_SERVICE_NAME) bash -c "while ! (mysqladmin ping -h db -uroot -p$$(cat secrets/db_root_password.txt) --silent); do sleep 1; done"
 	$(DOCKER_BIN) exec -it -u www-data $(WEB_SERVICE_NAME) bash -c "/usr/local/bin/php artisan app:install --db-host=db --db-user=$$(cat $(SECRETS_DIR)db_user.txt) --db-pass=$$(cat $(SECRETS_DIR)db_password.txt) --db-name=supportpal"
+	$(MAKE) restart
 
 .PHONY: start
 start: ## Start the help desk.


### PR DESCRIPTION
https://docs.supportpal.com/current/Deploy+On+Docker#StartContainers is currently a step which one must run manually.

We can do it for the user after the `app:install` command has completed.

docs.supportpal.com will be updated to reflect this PR.