### PR TITLE
fix(docker-compose): require docker-compose >=1.25.5

### DIFF
--- a/templates/docker-compose/setup.sh
+++ b/templates/docker-compose/setup.sh
@@ -169,7 +169,7 @@ check_docker_compose() {
     exit 1
   fi
 
-  local min="1.24.0" version max="2.0.0"
+  local min="1.25.5" version max="2.0.0"
 
   version="$(docker-compose version --short | sed 's/^v//')"
   printf "checking docker-compose version %s >= %s ...\n" "$version" "$min"


### PR DESCRIPTION
All of the docker-compose yml files use docker-compose 3.8 syntax. 3.8 syntax was only added in 1.25.5 (https://docs.docker.com/compose/release-notes/)

Using docker-compose 1.25.0 you get:
```console
$ docker-compose -f docker-compose.secrets.yml run --rm -T configurator
ERROR: Version in "./docker-compose.secrets.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/
```