### PR TITLE
fix: allow access to any file in /resources/assets

### DIFF
--- a/configs/gateway/base.conf
+++ b/configs/gateway/base.conf
@@ -29,7 +29,7 @@ location ~* \.(css|gif|ico|je?pg|js|png|swf|txt|eot|ttf|woff|woff2|svg|map|webma
 }
 
 # Allow direct access to resources/assets files, if they don't exist show SupportPal 404 error page.
-location resources/assets/ {
+location /resources/assets/ {
     try_files $uri $uri/ @backend;
 }
 


### PR DESCRIPTION
Create a `.html` file in `/resources/assets` and try to load it. It will show the SupportPal 404 error page.

Suspect this will probably break usage on sub directory installations like `https://company.com/support/resources/assets/...` - needs further testing. Maybe need to use regex - http://nginx.org/en/docs/http/ngx_http_core_module.html#location