### PR TITLE
ci(linux): test on centos 8 stream

### DIFF
--- a/.github/workflows/linux-verify.yml
+++ b/.github/workflows/linux-verify.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - centos:8
+          - quay.io/centos/centos:stream8
           - ubuntu:18.04
           - ubuntu:20.04
           - debian:10

--- a/.github/workflows/linux-verify.yml
+++ b/.github/workflows/linux-verify.yml
@@ -3,6 +3,7 @@ name: linux install
 on:
   pull_request:
     paths:
+      - .github/workflows/linux-verify.yml
       - templates/linux/**/*
   schedule:
     - cron:  '0 0 * * *' # Midnight - every night


### PR DESCRIPTION
CentOS moved their docker images to quay.io and CentOS 8 is now EOL with the repositories being moved to vault.centos.org - https://stackoverflow.com/a/70930049/2653593