### PR TITLE
chore(docker): remove os from image names

### DIFF
--- a/templates/aws/eb/HA/cron/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/cron/docker-compose.yml.dist
@@ -22,7 +22,7 @@ services:
 
     supportpal_cron:
         container_name: '${CRON_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron'
         depends_on:
             - mailer
         volumes:

--- a/templates/aws/eb/HA/cron/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/cron/docker-compose.yml.dist
@@ -42,7 +42,7 @@ services:
 
     supportpal_mq:
         container_name: '${MQ_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq'
         volumes:
             - supportpal_resources:/supportpal/resources
             - supportpal_app:/supportpal/app

--- a/templates/aws/eb/HA/web/docker-compose.yml.dist
+++ b/templates/aws/eb/HA/web/docker-compose.yml.dist
@@ -23,7 +23,7 @@ services:
 
     supportpal:
         container_name: '${WEB_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web'
         volumes:
             - supportpal_resources:/supportpal/resources
             - supportpal_app:/supportpal/app
@@ -41,7 +41,7 @@ services:
 
     supportpal_websockets:
         container_name: '${WS_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws'
         working_dir: /supportpal
         volumes:
             - supportpal_resources:/supportpal/resources

--- a/templates/aws/eb/Preview/docker-compose.yml.dist
+++ b/templates/aws/eb/Preview/docker-compose.yml.dist
@@ -97,7 +97,7 @@ services:
 
     supportpal_mq:
         container_name: '${MQ_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq'
         volumes:
             - supportpal_resources:/supportpal/resources
             - supportpal_app:/supportpal/app

--- a/templates/aws/eb/Preview/docker-compose.yml.dist
+++ b/templates/aws/eb/Preview/docker-compose.yml.dist
@@ -26,7 +26,7 @@ services:
 
     supportpal:
         container_name: '${WEB_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web'
         depends_on:
             - redis
         volumes:
@@ -49,7 +49,7 @@ services:
 
     supportpal_cron:
         container_name: '${CRON_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron'
         depends_on:
             - redis
             - mailer
@@ -72,7 +72,7 @@ services:
 
     supportpal_websockets:
         container_name: '${WS_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws'
         restart: always
         depends_on:
             - redis

--- a/templates/aws/eb/Single/docker-compose.yml.dist
+++ b/templates/aws/eb/Single/docker-compose.yml.dist
@@ -97,7 +97,7 @@ services:
 
     supportpal_mq:
         container_name: '${MQ_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq'
         volumes:
             - supportpal_resources:/supportpal/resources
             - supportpal_app:/supportpal/app

--- a/templates/aws/eb/Single/docker-compose.yml.dist
+++ b/templates/aws/eb/Single/docker-compose.yml.dist
@@ -26,7 +26,7 @@ services:
 
     supportpal:
         container_name: '${WEB_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web'
         depends_on:
             - redis
         volumes:
@@ -49,7 +49,7 @@ services:
 
     supportpal_cron:
         container_name: '${CRON_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron'
         depends_on:
             - redis
             - mailer
@@ -72,7 +72,7 @@ services:
 
     supportpal_websockets:
         container_name: '${WS_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws'
         restart: always
         depends_on:
             - redis

--- a/templates/docker-compose/docker-compose.prod.yml
+++ b/templates/docker-compose/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
 
     supportpal_cron:
         container_name: '${CRON_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-cron'
         restart: always
         depends_on:
             - db

--- a/templates/docker-compose/docker-compose.yml
+++ b/templates/docker-compose/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
     supportpal:
         container_name: '${WEB_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-web'
         restart: always
         depends_on:
             - db
@@ -59,7 +59,7 @@ services:
 
     supportpal_websockets:
         container_name: '${WS_SERVICE_NAME}'
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-ws'
         restart: always
         depends_on:
             - db
@@ -78,7 +78,7 @@ services:
     supportpal_mq:
         container_name: '${MQ_SERVICE_NAME}'
         user: www-data
-        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq-buster'
+        image: 'public.ecr.aws/supportpal/helpdesk:${APP_VERSION}-mq'
         restart: always
         depends_on:
             - db


### PR DESCRIPTION
In v4.0 we're removing the OS from the image names as we don't intend to maintain multiple images with different OS versions i.e. buster and bullseye. Buster is also EOL soon and we don't want to have to change the image name every X years based on Debian's EOL policies.