### PR TITLE
fix: adapt https to 4.0 structure

### DIFF
--- a/configs/letsencrypt/create-self-signed.sh
+++ b/configs/letsencrypt/create-self-signed.sh
@@ -48,7 +48,7 @@ fi
 echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.https.yml run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \

--- a/configs/letsencrypt/init-letsencrypt.sh
+++ b/configs/letsencrypt/init-letsencrypt.sh
@@ -57,7 +57,7 @@ fi
 echo "### Creating dummy certificate for $domains ..."
 path="/etc/letsencrypt/live/$domains"
 mkdir -p "$data_path/conf/live/$domains"
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.https.yml run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
     -keyout '$path/privkey.pem' \
     -out '$path/fullchain.pem' \
@@ -66,11 +66,11 @@ echo
 
 
 echo "### Starting nginx ..."
-docker-compose up --force-recreate -d gateway
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.https.yml up --force-recreate -d gateway
 echo
 
 echo "### Deleting dummy certificate for $domains ..."
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.https.yml run --rm --entrypoint "\
   rm -Rf /etc/letsencrypt/live/$domains && \
   rm -Rf /etc/letsencrypt/archive/$domains && \
   rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
@@ -93,7 +93,7 @@ esac
 # Enable staging mode if needed
 if [ $staging != "0" ]; then staging_arg="--staging"; else staging_arg=""; fi
 
-docker-compose run --rm --entrypoint "\
+docker-compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.https.yml run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/certbot \
     $staging_arg \
     $email_arg \

--- a/templates/docker-compose/docker-compose.https.yml
+++ b/templates/docker-compose/docker-compose.https.yml
@@ -7,8 +7,6 @@ services:
             - ./ssl/certbot/conf:/etc/letsencrypt
             - ./ssl/certbot/www:/var/www/certbot
             - ./gateway/reload.sh:/docker-entrypoint.d/reload.sh
-        environment:
-            DOMAIN_NAME: ${DOMAIN_NAME}
         ports:
             - '${HTTPS_REMOTE_PORT}:443'
 


### PR DESCRIPTION
Fixes issue: #89 

The issue is fixed by explicitly referring to the new files instead of relying implicitly on docker-override.yml