### PR TITLE
fix(linux): use develop branch of gdraheim/docker-systemctl-replacement

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -195,7 +195,7 @@ systemd() {
 
     install python3
     SYSTEMCTL=$(which systemctl || echo '/bin/systemctl')
-    curl -o "$SYSTEMCTL" https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py
+    curl -o "$SYSTEMCTL" https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/develop/files/docker/systemctl3.py
     chmod +x "$SYSTEMCTL"
     systemctl "$1" "$2"
   elif [[ $os_type == 'debian' ]] || [[ $os_type == 'ubuntu' ]]; then


### PR DESCRIPTION
MySQL 8.0.29 changed the systemd file to:
```
ExecStartPre=+/usr/share/mysql-8.0/mysql-systemd-start pre
```

This is valid per https://www.freedesktop.org/software/systemd/man/systemd.service.html
> If the executable path is prefixed with "+" then the process is executed with full privileges. In this mode privilege restrictions configured with User=, Group=, CapabilityBoundingSet= or the various file system namespacing options (such as PrivateDevices=, PrivateTmp=) are not applied to the invoked command line (but still affect any other ExecStart=, ExecStop=, … lines).

Support for "Special executable prefixes" is missing on the master branch, but is partially implemented on the develop branch (see issue 97 in https://github.com/gdraheim/docker-systemctl-replacement)