### PR TITLE
fix: send requests to caddy rather than apache

### DIFF
--- a/templates/docker-monolithic/docker-compose.yml
+++ b/templates/docker-monolithic/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: 'public.ecr.aws/supportpal/helpdesk-monolithic:4.0.4'
     restart: always
     ports:
-      - '80:8080'
+      - '80:80'
     volumes:
       - supportpal_db:/var/lib/mysql
       - supportpal_config:/var/www/supportpal/config/production


### PR DESCRIPTION
We want to send requests to caddy rather than Apache. caddy will handle HTTP to HTTPS redirects if appropriate.

`upgrade.sh` overwrites `docker-compose.yml` and https://docs.supportpal.com/current/Upgrade+Guide#UpgradeDockerMonolithic recommends to run it, so I think this change should be OK.