### PR TITLE
fix: shellcheck notice

### DIFF
--- a/templates/docker-monolithic/setup.sh
+++ b/templates/docker-monolithic/setup.sh
@@ -17,6 +17,7 @@ while [[ "$#" -gt 0 ]]; do
     exit 1
     ;;
   esac
+  # shellcheck disable=SC2317
   shift
 done
 


### PR DESCRIPTION
```
In setup.sh line 20:
  shift
  ^---^ SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).
```

I prefer to keep the line because if we add more options in the future then we'll no doubt forget to add `shift` back.