### PR TITLE
fix(docker-monolithic): stopping services in restore.sh

### DIFF
--- a/templates/docker-monolithic/restore.sh
+++ b/templates/docker-monolithic/restore.sh
@@ -26,7 +26,7 @@ if [[ "$GTE_v420" = "0" ]]; then COMMAND_PATH="/var/www/supportpal"; else COMMAN
 echo "Found ${LAST_BACKUP_FILE}..."
 
 echo "Stopping services..."
-docker exec supportpal bash -c "find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"  > /dev/null
+docker exec supportpal bash -c "sudo find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"  > /dev/null
 
 echo "Restoring..."
 


### PR DESCRIPTION
Fixes the below:

```
Stopping services...
sshd
warning: /etc/service/sshd: unable to open supervise/ok: access denied
cron
warning: /etc/service/cron: unable to open supervise/ok: access denied
horizon
warning: /etc/service/horizon: unable to open supervise/ok: access denied
caddy
warning: /etc/service/caddy: unable to open supervise/ok: access denied
meilisearch
warning: /etc/service/meilisearch: unable to open supervise/ok: access denied
apache
warning: /etc/service/apache: unable to open supervise/ok: access denied
ws
warning: /etc/service/ws: unable to open supervise/ok: access denied
phpfpm
warning: /etc/service/phpfpm: unable to open supervise/ok: access denied
postfix
warning: /etc/service/postfix: unable to open supervise/ok: access denied

```