### PR TITLE
fix(docker-monolithic): remove pipes to /dev/null

### DIFF
--- a/templates/docker-monolithic/backup.sh
+++ b/templates/docker-monolithic/backup.sh
@@ -13,7 +13,7 @@ GTE_v420="$(docker exec supportpal php -r "\$release = require '/var/www/support
 if [[ "$GTE_v420" = "0" ]]; then COMMAND_PATH="/var/www/supportpal"; else COMMAND_PATH="/var/www/supportpal/app-manager"; fi
 
 echo "Stopping services..."
-docker exec supportpal bash -c "find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"  > /dev/null
+docker exec supportpal bash -c "find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"
 
 echo 'Backing up filesystem...'
 docker exec supportpal bash -c "mkdir -p ${TEMP_BACKUP_DIR}/filesystem-${TIMESTAMP}/config/production" # create the farthest directory
@@ -43,6 +43,6 @@ docker cp "supportpal:${TEMP_BACKUP_DIR}/${APP_BACKUP_NAME}" "${BACKUP_DIR}/"
 docker exec -u root supportpal bash -c "rm -rf ${TEMP_BACKUP_DIR}/"
 
 echo "Restarting services..."
-docker restart supportpal 2> /dev/null
+docker restart supportpal
 
 echo "Backup created successfully at ${PWD}/${BACKUP_DIR}/${APP_BACKUP_NAME}"

--- a/templates/docker-monolithic/restore.sh
+++ b/templates/docker-monolithic/restore.sh
@@ -26,14 +26,14 @@ if [[ "$GTE_v420" = "0" ]]; then COMMAND_PATH="/var/www/supportpal"; else COMMAN
 echo "Found ${LAST_BACKUP_FILE}..."
 
 echo "Stopping services..."
-docker exec supportpal bash -c "sudo find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"  > /dev/null
+docker exec supportpal bash -c "sudo find -L /etc/service -maxdepth 1 -mindepth 1 -type d ! -name 'redis' ! -name 'mysql' -printf '%f\n' -exec sv stop {} \;"
 
 echo "Restoring..."
 
 docker exec supportpal bash -c "mkdir -p ${TEMP_BACKUP_DIR}"
 docker cp "${LAST_BACKUP_DIR}/${LAST_BACKUP_FILE}" "supportpal:${TEMP_BACKUP_DIR}/"
 TAR_OUTPUT=$(docker exec supportpal bash -c "cd ${TEMP_BACKUP_DIR} && tar -xvzf ${LAST_BACKUP_FILE}")
-docker exec supportpal bash -c "cd ${COMMAND_PATH} && php artisan app:restore ${TEMP_BACKUP_DIR}/${LAST_BACKUP_FILE} --no-verify --force" > /dev/null
+docker exec supportpal bash -c "cd ${COMMAND_PATH} && php artisan app:restore ${TEMP_BACKUP_DIR}/${LAST_BACKUP_FILE} --no-verify --force"
 
 # If backup generated via docker, restore volumes.
 if echo "${TAR_OUTPUT}" | grep -qs '^volumes-monolithic/$'; then
@@ -48,5 +48,5 @@ if echo "${TAR_OUTPUT}" | grep -qs '^volumes-monolithic/$'; then
 fi
 
 echo "Restarting services..."
-docker compose down 2> /dev/null
+docker compose down
 docker compose up -d


### PR DESCRIPTION
Piping to `/dev/null` makes it impossible to understand why the script is failing.