### PR TITLE
fix(docker-monolithic): add stop_grace_period

### DIFF
--- a/templates/docker-monolithic/docker-compose.yml
+++ b/templates/docker-monolithic/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: supportpal
     image: 'public.ecr.aws/supportpal/helpdesk-monolithic:5.1.2'
     restart: always
+    stop_grace_period: 60s
     ports:
       - '80:80'
     env_file:


### PR DESCRIPTION
Sometimes it takes longer than 10 seconds for horizon to shut down, which results in an ungraceful shutdown. 

The value (`60s`) is copied from the supportpal_mq container on docker-compose.