### PR TITLE
fix(docker-monolithic): add CAP_SYS_NICE

### DIFF
--- a/templates/docker-monolithic/docker-compose.yml
+++ b/templates/docker-monolithic/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: 'public.ecr.aws/supportpal/helpdesk-monolithic:5.1.2'
     restart: always
     stop_grace_period: 60s
+    cap_add: [ SYS_NICE ]
     ports:
       - '80:80'
     env_file:


### PR DESCRIPTION
`/var/log/mysql.log` gets spammed with `mbind: Operation not permitted` messages. This is well documented on Docker's official  mysql image:
* https://www.github.com/docker-library/mysql/issues/352#issuecomment-396406509
* https://www.github.com/docker-library/mysql/issues/303#issuecomment-822684258

I do not believe there should be any side effects of modifying the seccomp profile in this way - https://docs.docker.com/engine/security/seccomp/
* `get_mempolicy`	Syscall that modifies kernel memory and NUMA settings. Already gated by `CAP_SYS_NICE`.
* `mbind`	Syscall that modifies kernel memory and NUMA settings. Already gated by `CAP_SYS_NICE`.
* `set_mempolicy`	Syscall that modifies kernel memory and NUMA settings. Already gated by `CAP_SYS_NICE`.