### PR TITLE
chore(docker-compose): update gateway dependencies

### DIFF
--- a/templates/docker-compose/docker-compose.yml
+++ b/templates/docker-compose/docker-compose.yml
@@ -7,7 +7,6 @@ services:
         restart: always
         depends_on:
             - supportpal
-            - supportpal_websockets
         environment:
             WEB_CONTAINER: ${WEB_SERVICE_NAME}
             WS_SERVICE_NAME: ${WS_SERVICE_NAME}


### PR DESCRIPTION
If the `supportpal_websockets` container terminates, then it causes the `gateway` to stop. I don't believe this is necessary as nginx will just show a gateway timeout error so there's no need for an explicit dependency?

It should be safe to merge this prior to release of 5.2.0?