### PR TITLE
fix(docker-monolithic): backup with s3 storage configured

### DIFF
--- a/templates/docker-monolithic/backup.sh
+++ b/templates/docker-monolithic/backup.sh
@@ -23,7 +23,7 @@ docker exec supportpal bash -c "cp -r /var/www/supportpal/addons ${TEMP_BACKUP_D
 docker exec supportpal bash -c "cd ${TEMP_BACKUP_DIR} && tar -czf ${FILESYSTEM_BACKUP_NAME} filesystem-${TIMESTAMP}"
 
 echo 'Backing up database...'
-DB_BACKUP_PATH=$(docker exec supportpal bash -c "cd ${COMMAND_PATH} && php artisan db:backup | grep -oE '/var/www/supportpal/.*/database-.*'")
+DB_BACKUP_PATH=$(docker exec supportpal bash -c "cd ${COMMAND_PATH} && php artisan db:backup --store-local | grep -oE '/var/www/supportpal/.*/database-.*'")
 DB_FILE_NAME=$(echo "${DB_BACKUP_PATH}" | xargs basename)
 docker exec supportpal bash -c "mv ${DB_BACKUP_PATH} ${TEMP_BACKUP_DIR}/"
 


### PR DESCRIPTION
The backup crashes after `Backing up database...` because the grep doesn't match a path.
```console
# docker exec supportpal bash -c "php app-manager/artisan db:backup"
[2024-01-31 11:57:31] Backing up database...
[2024-01-31 11:57:32] Uploading backup...
[2024-01-31 11:57:33] The backup was generated at https://s3.foo.com/support.foo.com/backups/database-2024-01-31-11-57-31.sql.gz

```