### PR TITLE
fix(docker-compose): upgrade.sh shellcheck issues

### DIFF
--- a/templates/docker-compose/upgrade.sh
+++ b/templates/docker-compose/upgrade.sh
@@ -3,6 +3,6 @@
 set -eu -o pipefail
 
 ${MAKE} create_volumes
-${DOCKER_COMPOSE_BIN} ${COMPOSE_FILES} up -d supportpal
-${DOCKER_BIN} exec -it ${WEB_SERVICE_NAME} bash /scripts/upgrade-helpdesk.sh
+${DOCKER_COMPOSE_BIN} "${COMPOSE_FILES}" up -d supportpal
+${DOCKER_BIN} exec -it "${WEB_SERVICE_NAME}" bash /scripts/upgrade-helpdesk.sh
 ${MAKE} start


### PR DESCRIPTION
```
In upgrade.sh line 6:
${DOCKER_COMPOSE_BIN} ${COMPOSE_FILES} up -d supportpal
                      ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${DOCKER_COMPOSE_BIN} "${COMPOSE_FILES}" up -d supportpal


In upgrade.sh line 7:
${DOCKER_BIN} exec -it ${WEB_SERVICE_NAME} bash /scripts/upgrade-helpdesk.sh
                       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${DOCKER_BIN} exec -it "${WEB_SERVICE_NAME}" bash /scripts/upgrade-helpdesk.sh

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```