### PR TITLE
fix(linux): add reload privilege to mysql user

### DIFF
--- a/templates/linux/setup.sh
+++ b/templates/linux/setup.sh
@@ -531,6 +531,7 @@ install_mysql() {
   mysql --user="root" --password="${root_password}" -e "CREATE DATABASE \`${database}\`;"
   mysql --user="root" --password="${root_password}" -e "CREATE USER '${username}'@'localhost' IDENTIFIED BY '$user_password';"
   mysql --user="root" --password="${root_password}" -e "GRANT ALL PRIVILEGES ON \`${database}\`.* TO '${username}'@'localhost';"
+  mysql --user="root" --password="${root_password}" -e "GRANT RELOAD,PROCESS ON *.* TO '${username}'@'localhost';"
   mysql --user="root" --password="${root_password}" -e "FLUSH PRIVILEGES;"
 }
 


### PR DESCRIPTION
```
$ sudo -u www-data -H php app-manager/artisan app:backup
[2024-11-19 13:33:21] Backing up database...
The dump process failed with a none successful exitcode.
Exitcode
========
2: Misuse of shell builtins

Output
======
<no output>

Error Output
============
mysqldump: Couldn't execute 'FLUSH TABLES': Access denied; you need (at least one of) the RELOAD or FLUSH_TABLES privilege(s) for this operation (1227)
```