### PR TITLE
fix(docker-compose): update ws nginx config

### DIFF
--- a/configs/gateway/base.conf
+++ b/configs/gateway/base.conf
@@ -46,7 +46,6 @@ location ~ \.php($|/) {
 
 location @ws  {
     proxy_pass             http://${WS_SERVICE_NAME}:6001;
-    proxy_set_header Host  $host;
     proxy_read_timeout     60;
     proxy_connect_timeout  60;
     proxy_redirect         off;
@@ -56,5 +55,9 @@ location @ws  {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection 'upgrade';
     proxy_set_header Host $host;
+    proxy_set_header Scheme $scheme;
+    proxy_set_header SERVER_PORT $server_port;
+    proxy_set_header REMOTE_ADDR $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_cache_bypass $http_upgrade;
 }


### PR DESCRIPTION
The duplicate `proxy_set_header Host $host` seems to break Laravel reverb 🤔  these changes do not alter the behaviour of the existing web socket server in v5.