### PR TITLE
fix(docker-compose): use mysql 8.0.46

### DIFF
--- a/templates/docker-compose/docker-compose.yml
+++ b/templates/docker-compose/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
     db:
         container_name: '${DATABASE_SERVICE_NAME}'
-        image: mysql:8.0.23
+        image: mysql:8.0.46
         restart: always
         environment:
             MYSQL_DATABASE: ${MYSQL_DATABASE}


### PR DESCRIPTION
One of the migrations in v6 requires MySQL 8.0.29+